### PR TITLE
Refer explicitly to the class

### DIFF
--- a/src/main/java/Main.java
+++ b/src/main/java/Main.java
@@ -15,9 +15,9 @@ public class Main {
         expense.setOrderid("1232");
 
 
-        JAXBContext context = JAXBContext.newInstance("generated");
+        JAXBContext context = JAXBContext.newInstance(ObjectFactory.class);
         Marshaller marshaller = context.createMarshaller();
-        marshaller.setProperty("jaxb.formatted.output",Boolean.TRUE);
-        marshaller.marshal(expense,System.out);
+        marshaller.setProperty("jaxb.formatted.output", Boolean.TRUE);
+        marshaller.marshal(expense, System.out);
     }
 }


### PR DESCRIPTION
Reflects a best practice: in case of refactoring (package change), the compiler will realize that the reference to ObjectFactory also needs to be changed. (If somebody rename the package but forgets to change the call to JAXBContext, the failure will be visible at compile time rather than at run time.)